### PR TITLE
unique app name

### DIFF
--- a/tenant_users/tenants/__init__.py
+++ b/tenant_users/tenants/__init__.py
@@ -1,0 +1,1 @@
+default_app_config = 'tenant_users.tenants.apps.TenantsConfig'

--- a/tenant_users/tenants/apps.py
+++ b/tenant_users/tenants/apps.py
@@ -1,0 +1,6 @@
+from django.apps import AppConfig
+
+
+class TenantsConfig(AppConfig):
+    name = 'tenant_users.tenants'
+    label = 'tenant_users.tenants'


### PR DESCRIPTION
I have "tenants" in my shared app and it's conflicting with "tenant_users.tenants".
This fix allows me to have "tenants" as the "user app" 
and "tenant_users.tenant" as the "django package app"