### PR TITLE
Use extra fields when creating TenantUser

### DIFF
--- a/tenant_users/tenants/models.py
+++ b/tenant_users/tenants/models.py
@@ -335,9 +335,9 @@ class UserProfile(AbstractBaseUser, PermissionsMixinFacade):
     def has_verified_email(self):
         return self.is_verified == True
 
-    def delete(self, force_drop=False):
+    def delete(self, force_drop=False, **kwargs):
         if force_drop:
-            super(UserProfile, self).delete(force_drop=True)
+            super(UserProfile, self).delete(**kwargs)
         else:
             raise DeleteError("UserProfile.objects.delete_user() should be used.")
 

--- a/tenant_users/tenants/models.py
+++ b/tenant_users/tenants/models.py
@@ -238,6 +238,8 @@ class UserProfileManager(BaseUserManager):
         profile.is_active = True
         profile.is_verified = is_verified
         profile.set_password(password)
+        for attr, value in extra_fields.items():
+            setattr(profile, attr, value)
         profile.save()
 
         # Get public tenant tenant and link the user (no perms)

--- a/tenant_users/tenants/utils.py
+++ b/tenant_users/tenants/utils.py
@@ -12,7 +12,7 @@ def get_current_tenant():
     return tenant
 
 
-def create_public_tenant(domain_url, owner_email):
+def create_public_tenant(domain_url, owner_email, **owner_extra):
     UserModel = get_user_model()
     TenantModel = get_tenant_model()
     public_schema_name = get_public_schema_name()
@@ -20,9 +20,11 @@ def create_public_tenant(domain_url, owner_email):
     if TenantModel.objects.filter(schema_name=public_schema_name).first():
         raise ExistsError("Public tenant already exists")
 
-    # Create public tenant user. This user doesn't go through object manager 
+    # Create public tenant user. This user doesn't go through object manager
     # create_user function because public tenant does not exist yet
-    profile = UserModel.objects.create(email=owner_email, is_active=True)
+    profile = UserModel.objects.create(
+        email=owner_email, is_active=True, **owner_extra
+    )
     profile.set_unusable_password()
     profile.save()
 


### PR DESCRIPTION
I needed to init my users with some custom fields and when creating the users I noticed the `extra_fields` param wasn't being used.

Thats also needed in `create_public_tenant` so I added `owner_extra` there. 