### PR TITLE
Added dunder string for UserTenantPermissions class

### DIFF
--- a/tenant_users/permissions/models.py
+++ b/tenant_users/permissions/models.py
@@ -107,3 +107,7 @@ class UserTenantPermissions(PermissionsMixin, AbstractBaseUserFacade):
     is_staff = models.BooleanField(_('staff status'), default=False,
                                    help_text=_('Designates whether the user can log into this tenants '
                                                'admin site.'))
+
+    def __str__(self):
+        """ Cleaner admin view for tenant object """
+        return self.profile.username


### PR DESCRIPTION
We need a way to override __str__ method on the UserTenantPermissions class but magically it works under the hood, I suggest to merge for cleaner admin interface. specifically there is no implications on the real code. 