### PR TITLE
Remove deprecation warning for django >= 3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ We follow [Semantic Versions](https://semver.org/) starting at the `0.4.0` relea
 
 ## {{ Next Version }}
 
+## 1.1.1 (tba)
+
+### Misc
+
+- Remove deprecation warning regarding default_app_config for django >= 3.2
+
 ## 1.1.0 (2022-10-01)
 
 ### Features

--- a/tenant_users/tenants/__init__.py
+++ b/tenant_users/tenants/__init__.py
@@ -1,1 +1,5 @@
-default_app_config = 'tenant_users.tenants.apps.TenantsConfig'
+import django
+
+
+if django.VERSION < (3, 2):
+    default_app_config = 'tenant_users.tenants.apps.TenantsConfig'


### PR DESCRIPTION
# I'm helping!

## Checklist
- [X] I have double checked that there are no unrelated changes in this pull request (old patches, accidental config files, etc.)
- [ ] I have created at least one test case for the changes I have made
- [ ] I have updated the documentation for the changes I have made
- [X] I have added my changes to the `CHANGELOG.md`

## Pull Request type
Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [X] Other (please describe): Removal of a deprecation warning for django >= 3.2