### PR TITLE
Remove nargs

### DIFF
--- a/tenant_users/tenants/management/commands/create_public_tenant.py
+++ b/tenant_users/tenants/management/commands/create_public_tenant.py
@@ -10,14 +10,12 @@ class Command(BaseCommand):
     def add_arguments(self, parser):
         parser.add_argument(
             "--domain_url",
-            nargs=1,
             required=True,
             type=str,
             help="The URL for the public tenant's domain.",
         )
         parser.add_argument(
             "--owner_email",
-            nargs=1,
             required=True,
             type=str,
             help="Email address of the owner user.",


### PR DESCRIPTION
# Remove nargs in the create_public_tenant!

<!--
Thank you for submitting a Pull Request. We appreciate it!

Please, fill in all the required information
to make our review and merging processes easier.
-->

## Checklist

<!--
Please check everything that applies:
-->

- [x] I have double checked that there are no unrelated changes in this pull request (old patches, accidental config files, etc.)
- [ ] I have created at least one test case for the changes I have made
- [ ] I have updated the documentation for the changes I have made
- [ ] I have added my changes to the `CHANGELOG.md`

## Pull Request type

<!--
Please try to limit your pull request to one type, submit multiple pull requests if needed.
-->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Related issue(s)

<!--
Mark what issues this Pull Request closes or references.

Format is:
- Closes #issue-number
- Refs #issue-number

Example. Refs #0
Documentation: https://blog.github.com/2013-05-14-closing-issues-via-pull-requests/
-->

## Other Information

<!--
If you have any other comments, feel free to share!
-->
When creating a public tenant using the management command, the system can't find any domain registered in our database. Checked the database, the domain and the email returns a stringified list. 

The problem on the `nargs` parameter in the `add_argument` method. Per [documentation](https://docs.python.org/3/library/argparse.html#nargs)

>  N arguments from the command line will be gathered together into a list.