### PR TITLE
Add feature: DRF Permission Class

### DIFF
--- a/django_test_app/companies/migrations/0001_initial.py
+++ b/django_test_app/companies/migrations/0001_initial.py
@@ -1,7 +1,6 @@
 from django.db import migrations, models
-from django_tenants.postgresql_backend.base import (
-    _check_schema_name as check_schema_name,
-)
+from django_tenants.postgresql_backend.base import \
+    _check_schema_name as check_schema_name
 
 
 class Migration(migrations.Migration):

--- a/tenant_users/tenants/models.py
+++ b/tenant_users/tenants/models.py
@@ -9,10 +9,8 @@ from django.utils.translation import gettext_lazy as _
 from django_tenants.models import TenantMixin
 from django_tenants.utils import get_public_schema_name, get_tenant_model
 
-from tenant_users.permissions.models import (
-    PermissionsMixinFacade,
-    UserTenantPermissions,
-)
+from tenant_users.permissions.models import (PermissionsMixinFacade,
+                                             UserTenantPermissions)
 
 # An existing user removed from a tenant
 tenant_user_removed = Signal()

--- a/tenant_users/tenants/tasks.py
+++ b/tenant_users/tenants/tasks.py
@@ -4,15 +4,11 @@ from typing import Optional, Tuple
 from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.db import transaction
-from django_tenants.utils import (
-    get_multi_type_database_field_name,
-    get_public_schema_name,
-    get_tenant_domain_model,
-    get_tenant_model,
-    get_tenant_types,
-    has_multi_type_tenants,
-    schema_context,
-)
+from django_tenants.utils import (get_multi_type_database_field_name,
+                                  get_public_schema_name,
+                                  get_tenant_domain_model, get_tenant_model,
+                                  get_tenant_types, has_multi_type_tenants,
+                                  schema_context)
 
 from tenant_users.tenants.models import ExistsError, InactiveError, SchemaError
 

--- a/tenant_users/tenants/utils.py
+++ b/tenant_users/tenants/utils.py
@@ -2,14 +2,10 @@ from typing import Optional
 
 from django.contrib.auth import get_user_model
 from django.db import connection
-from django_tenants.utils import (
-    get_multi_type_database_field_name,
-    get_public_schema_name,
-    get_tenant_domain_model,
-    get_tenant_model,
-    get_tenant_types,
-    has_multi_type_tenants,
-)
+from django_tenants.utils import (get_multi_type_database_field_name,
+                                  get_public_schema_name,
+                                  get_tenant_domain_model, get_tenant_model,
+                                  get_tenant_types, has_multi_type_tenants)
 
 from tenant_users.tenants.models import ExistsError, SchemaError
 

--- a/tests/test_tenants/test_tasks.py
+++ b/tests/test_tenants/test_tasks.py
@@ -9,7 +9,8 @@ from django.db import DatabaseError, connection
 from django_tenants.utils import get_tenant_model
 
 from tenant_users.tenants.models import ExistsError, InactiveError
-from tenant_users.tenants.tasks import INACTIVE_USER_ERROR_MESSAGE, provision_tenant
+from tenant_users.tenants.tasks import (INACTIVE_USER_ERROR_MESSAGE,
+                                        provision_tenant)
 
 #: Constants
 TenantModel = get_tenant_model()

--- a/tests/test_tenants/test_tenants_models.py
+++ b/tests/test_tenants/test_tenants_models.py
@@ -1,18 +1,12 @@
 import pytest
 from django.contrib.auth import get_user_model
 from django.contrib.auth.models import Group, Permission
-from django_tenants.utils import (
-    get_public_schema_name,
-    get_tenant_model,
-    tenant_context,
-)
+from django_tenants.utils import (get_public_schema_name, get_tenant_model,
+                                  tenant_context)
 
 from tenant_users.permissions.models import UserTenantPermissions
-from tenant_users.tenants.models import (
-    TENANT_DELETE_ERROR_MESSAGE,
-    DeleteError,
-    ExistsError,
-)
+from tenant_users.tenants.models import (TENANT_DELETE_ERROR_MESSAGE,
+                                         DeleteError, ExistsError)
 from tenant_users.tenants.tasks import provision_tenant
 
 #: Constants


### PR DESCRIPTION
When using Django Rest Framework with `django-tenant-users`, an example of how to ensure that `TenantUser.tenants` can only access their respective resources. 

In this case, the use case is with SimpleJWT like so:

```
REST_FRAMEWORK = {
    "NON_FIELD_ERRORS_KEY": "errors",
    "DEFAULT_AUTHENTICATION_CLASSES": [
        "rest_framework_simplejwt.authentication.JWTAuthentication",
    ],
    "DEFAULT_PERMISSION_CLASSES": [
        "rest_framework.permissions.IsAuthenticated",
    ],
    "DEFAULT_PAGINATION_CLASS": "rest_framework.pagination.PageNumberPagination",
    "PAGE_SIZE": 10,
}
```