### PR TITLE
Fix: security risk in `tenant_cached_property` with malicious schema names

### DIFF
--- a/tenant_users/constants.py
+++ b/tenant_users/constants.py
@@ -1,0 +1,7 @@
+INACTIVE_USER_ERROR_MESSAGE = "Inactive user can't be used to provision a tenant."
+
+TENANT_DELETE_ERROR_MESSAGE = (
+    "calling delete on tenant instance is not supported, call delete_tenant instead"
+)
+
+TENANT_CACHE_NAME = "_tenant_cache"

--- a/tenant_users/permissions/functional.py
+++ b/tenant_users/permissions/functional.py
@@ -1,7 +1,7 @@
 from django.db import connection
 from django.utils.functional import cached_property
 
-from tenant_users.tenants.models import TENANT_CACHE_NAME
+from tenant_users.constants import TENANT_CACHE_NAME
 
 
 class tenant_cached_property(cached_property):  # noqa: N801

--- a/tenant_users/permissions/functional.py
+++ b/tenant_users/permissions/functional.py
@@ -20,14 +20,17 @@ class tenant_cached_property(cached_property):  # noqa: N801
         if instance is None:
             return self
 
+        if "_tenant_cache" not in instance.__dict__:
+            instance.__dict__["_tenant_cache"] = {}
+
+        tenant_cache = instance.__dict__["_tenant_cache"]
         current_schema = connection.schema_name
 
-        if current_schema not in instance.__dict__:
-            instance.__dict__[current_schema] = {}
-            res = instance.__dict__[current_schema][self.name] = self.func(instance)
-        elif self.name not in instance.__dict__[current_schema]:
-            res = instance.__dict__[current_schema][self.name] = self.func(instance)
-        else:
-            res = instance.__dict__[current_schema][self.name]
+        if current_schema not in tenant_cache:
+            tenant_cache[current_schema] = {}
+            tenant_cache[current_schema][self.name] = self.func(instance)
+        elif self.name not in tenant_cache[current_schema]:
+            tenant_cache[current_schema][self.name] = self.func(instance)
 
-        return res
+        return tenant_cache[current_schema][self.name]
+

--- a/tenant_users/permissions/functional.py
+++ b/tenant_users/permissions/functional.py
@@ -1,6 +1,8 @@
 from django.db import connection
 from django.utils.functional import cached_property
 
+from tenant_users.tenants.models import TENANT_CACHE_NAME
+
 
 class tenant_cached_property(cached_property):  # noqa: N801
     """A tenant-aware implementation of Django's cached_property decorator.
@@ -20,10 +22,10 @@ class tenant_cached_property(cached_property):  # noqa: N801
         if instance is None:
             return self
 
-        if "_tenant_cache" not in instance.__dict__:
-            instance.__dict__["_tenant_cache"] = {}
+        if TENANT_CACHE_NAME not in instance.__dict__:
+            instance.__dict__[TENANT_CACHE_NAME] = {}
 
-        tenant_cache = instance.__dict__["_tenant_cache"]
+        tenant_cache = instance.__dict__[TENANT_CACHE_NAME]
         current_schema = connection.schema_name
 
         if current_schema not in tenant_cache:
@@ -33,4 +35,3 @@ class tenant_cached_property(cached_property):  # noqa: N801
             tenant_cache[current_schema][self.name] = self.func(instance)
 
         return tenant_cache[current_schema][self.name]
-

--- a/tenant_users/tenants/models.py
+++ b/tenant_users/tenants/models.py
@@ -30,6 +30,8 @@ TENANT_DELETE_ERROR_MESSAGE = (
     "calling delete on tenant instance is not supported, call delete_tenant instead"
 )
 
+TENANT_CACHE_NAME = "_tenant_cache"
+
 
 class InactiveError(Exception):
     pass

--- a/tenant_users/tenants/models.py
+++ b/tenant_users/tenants/models.py
@@ -152,8 +152,10 @@ class TenantBase(TenantMixin):
         UserTenantPermissions.objects.filter(pk=user_tenant_perms.pk).delete()
         user_obj.tenants.remove(self)
         # Remove tenant specific cached attributes
-        if self.schema_name in user_obj.__dict__:
-            del user_obj.__dict__[self.schema_name]
+        if TENANT_CACHE_NAME in user_obj.__dict__:
+            cache = user_obj.__dict__[TENANT_CACHE_NAME]
+            if self.schema_name in cache:
+                del cache[self.schema_name]
 
         tenant_user_removed.send(
             sender=self.__class__,

--- a/tenant_users/tenants/models.py
+++ b/tenant_users/tenants/models.py
@@ -13,6 +13,10 @@ from tenant_users.permissions.models import (
     PermissionsMixinFacade,
     UserTenantPermissions,
 )
+from tenant_users.constants import (
+    TENANT_CACHE_NAME,
+    TENANT_DELETE_ERROR_MESSAGE,
+)
 
 # An existing user removed from a tenant
 tenant_user_removed = Signal()
@@ -25,12 +29,6 @@ tenant_user_created = Signal()
 
 # An existing user is deleted
 tenant_user_deleted = Signal()
-
-TENANT_DELETE_ERROR_MESSAGE = (
-    "calling delete on tenant instance is not supported, call delete_tenant instead"
-)
-
-TENANT_CACHE_NAME = "_tenant_cache"
 
 
 class InactiveError(Exception):
@@ -238,7 +236,7 @@ class TenantBase(TenantMixin):
 
 
 class UserProfileManager(BaseUserManager):
-    def _create_user(  # noqa: PLR0913
+    def _create_user(
         self,
         email,
         password,

--- a/tenant_users/tenants/tasks.py
+++ b/tenant_users/tenants/tasks.py
@@ -14,9 +14,9 @@ from django_tenants.utils import (
     schema_context,
 )
 
+from tenant_users.constants import INACTIVE_USER_ERROR_MESSAGE
 from tenant_users.tenants.models import ExistsError, InactiveError, SchemaError
 
-INACTIVE_USER_ERROR_MESSAGE = "Inactive user can't be used to provision a tenant."
 UserModel = get_user_model()
 TenantModel = get_tenant_model()
 DomainModel = get_tenant_domain_model()

--- a/tests/test_tenants/test_functional.py
+++ b/tests/test_tenants/test_functional.py
@@ -4,13 +4,17 @@ import pytest
 from django.db import connection
 from django.utils.functional import cached_property
 
+from tenant_users.constants import TENANT_CACHE_NAME
 from tenant_users.permissions.functional import tenant_cached_property
 
 
 class MockTenant:
+    def __init__(self):
+        self.call_count = 0
 
     @tenant_cached_property
     def tenant_aware_cached_property(self):
+        self.call_count += 1
         current_schema = connection.schema_name
         return f"aware {current_schema}"
 
@@ -20,7 +24,8 @@ class MockTenant:
         return f"unaware {current_schema}"
 
 
-def test_tenant_cached_property():
+def test_tenant_cached_property_basic_behavior():
+    """Test the basic behavior of tenant_cached_property with schema changes."""
     instance = MockTenant()
 
     # Mock the schema name for the first access
@@ -28,19 +33,18 @@ def test_tenant_cached_property():
         assert instance.tenant_aware_cached_property == "aware schema_one"
         assert instance.tenant_unaware_cached_property == "unaware schema_one"
 
-    # Mock the schema name for a second schema
+    cache = instance.__dict__[TENANT_CACHE_NAME]
+
+    # Mock the schema name for a second schema (concurrent access)
     with patch.object(connection, "schema_name", "schema_two"):
         assert instance.tenant_aware_cached_property == "aware schema_two"
-        assert "tenant_aware_cached_property" in instance.__dict__["schema_two"]
+        assert "tenant_aware_cached_property" in cache["schema_two"]
         assert instance.tenant_unaware_cached_property == "unaware schema_one"
         with pytest.raises(KeyError) as exc_info:
-            instance.__dict__["schema_two"]["tenant_unaware_cached_property"]
+            cache["schema_two"]["tenant_unaware_cached_property"]
 
         assert str(exc_info.value) == "'tenant_unaware_cached_property'"
-        assert (
-            instance.__dict__["schema_two"]["tenant_aware_cached_property"]
-            == "aware schema_two"
-        )
+        assert cache["schema_two"]["tenant_aware_cached_property"] == "aware schema_two"
 
     # Accessing again with the first schema to check caching
     with patch.object(connection, "schema_name", "schema_one"):
@@ -52,13 +56,46 @@ def test_tenant_cached_property():
         assert instance.tenant_aware_cached_property == "aware schema_two"
         assert instance.tenant_unaware_cached_property == "unaware schema_one"
 
-    # Clear the cached property for a schema and test recalculation
-    with patch.object(connection, "schema_name", "schema_two"):
-        del instance.__dict__["schema_two"]["tenant_aware_cached_property"]
-        assert instance.tenant_aware_cached_property == "aware schema_two"
-        assert "tenant_aware_cached_property" in instance.__dict__["schema_two"]
+    # Verify caching is isolated per schema
+    assert "schema_one" in cache
+    assert "schema_two" in cache
+
+
+def test_tenant_cached_property_uses_a_dedicated_cache():
+    """Test a dedicated cache is used for tenant-aware properties."""
+    instance = MockTenant()
+
+    assert TENANT_CACHE_NAME not in instance.__dict__
+
+    with patch.object(connection, "schema_name", "schema_one"):
+        assert instance.tenant_aware_cached_property == "aware schema_one"
+
+    # The schema name should be a new key in our dedicated tenant cache dictionary
+    assert "schema_one" not in instance.__dict__
+    assert TENANT_CACHE_NAME in instance.__dict__
+    assert "schema_one" in instance.__dict__[TENANT_CACHE_NAME]
+
+
+def test_tenant_cached_property_value_is_not_recalculated():
+    """Test resetting the cache for a specific tenant schema."""
+    instance = MockTenant()
+
+    with patch.object(connection, "schema_name", "my_schema"):
+        assert instance.tenant_aware_cached_property == "aware my_schema"
+        assert instance.call_count == 1
+
+        # Another access should not trigger recalculation
+        assert instance.tenant_aware_cached_property == "aware my_schema"
+        assert instance.call_count == 1  # call count remains unchanged
+
+        # Clear the cache and access the value again, should trigger recalculation
+        cache = instance.__dict__[TENANT_CACHE_NAME]
+        del cache["my_schema"]["tenant_aware_cached_property"]
+        assert instance.tenant_aware_cached_property == "aware my_schema"
+        assert "tenant_aware_cached_property" in cache["my_schema"]
+        assert instance.call_count == 2  # call count is incremented
 
 
 def test_tenant_cached_property_instance_none():
-    # When instance is None, the property descriptor itself should be returned
+    """Test that the property descriptor itself is returned when instance is None."""
     assert isinstance(MockTenant.tenant_aware_cached_property, tenant_cached_property)


### PR DESCRIPTION
## Issue description

Assume our Django application allows certain users to add tenants (schemas) and specify a custom schema name via the `provision_tenant` function, with the option of omitting the timestamp suffix if desired. I think such a feature would introduce a potential security risk due to the current implementation of the `tenant_cached_property` decorator.

Here's its current implementation:
```python
from django.db import connection
from django.utils.functional import cached_property

class tenant_cached_property(cached_property):  # noqa: N801
    """A tenant-aware implementation of Django's cached_property decorator. [...]"""

    def __get__(self, instance, cls=None):
        if instance is None:
            return self
        current_schema = connection.schema_name
        if current_schema not in instance.__dict__:
            instance.__dict__[current_schema] = {}
            res = instance.__dict__[current_schema][self.name] = self.func(instance)
        elif self.name not in instance.__dict__[current_schema]:
            res = instance.__dict__[current_schema][self.name] = self.func(instance)
        else:
            res = instance.__dict__[current_schema][self.name]
        return res
```
This implementation stores tenant-specific properties in `instance.__dict__` using the current schema name (`connection.schema_name`) as a key. This behavior is generally fine, but it can cause issues if a malicious user creates a tenant with a schema name that matches an existing `User` attribute.

## Exploit scenario

For instance, a malicious user could choose `is_staff`, `is_superuser`, `is_verified`, `email` or `can_do_something_bad` as a schema name. When `@tenant_cached_property` is accessed in this tenant context, it assigns a non-empty dictionary to `user.can_do_something_bad` (or any such attribute). Since non-empty dictionaries evaluate to `True` in Python, this could result in unintended and potentially harmful behavior, especially if the application relies on these attributes for authorization or business logic.

## Proposed solutions

Admittedly, Django back-end validation should check whether the schema name in input is valid and it should prohibits some values: for instance in PostgreSQL, a schema name cannot start with `pg_`. `information_schema` is also an invalid schema name. More broadly speaking, I think it would be a good thing to ban custom schema names starting with an underscore. For all these reasons, modifying the application to enforce strict validation rules for schema names during tenant creation is essential.

But shouldn't we at least add a few warnings to the documentation? It should explain:
- why `provision_tenant` adds a timestamp to `tenant_slug` when no `schema_name` is provided,
- the risks associated with custom schema names and the importance of proper validation.

Another safeguard would be to maintain a **dedicated tenant cache dictionary** in `tenant_cached_property`. Instead of storing tenant-specific attributes directly in `instance.__dict__`, we could maintain a separate internal dictionary for tenant data.

This what this pull request does: it isolates tenant-specific data from other instance attributes.