### PR TITLE
adds `is_authenticated` proxy property to `AbstractBaseUserFacade`

### DIFF
--- a/tenant_users/permissions/models.py
+++ b/tenant_users/permissions/models.py
@@ -105,6 +105,10 @@ class AbstractBaseUserFacade:
     def is_anonymous(self):
         return False
 
+    @property
+    def is_authenticated(self):
+        return self.profile.is_authenticated
+
 
 class UserTenantPermissions(PermissionsMixin, AbstractBaseUserFacade):
     """Authorization model for managing per-tenant permissions in Django-tenant-users.

--- a/tests/test_tenants/test_permission_models.py
+++ b/tests/test_tenants/test_permission_models.py
@@ -14,6 +14,9 @@ def test_permissions_mixin_facade(public_tenant, tenant_user):
     ), "The tenant_user should not be equal to the owner of the tenant because he cannot be removed."
 
     user_tenant_perms: UserTenantPermissions = tenant_user.tenant_perms
+    assert user_tenant_perms.is_active is True
+    assert user_tenant_perms.is_anonymous is False
+    assert user_tenant_perms.is_authenticated is True
     user_tenant_perms.is_superuser = True
     user_tenant_perms.is_staff = True
     user_tenant_perms.save(update_fields=["is_superuser", "is_staff"])


### PR DESCRIPTION
the `AbstractBaseUserFacade` is a mixin for `UserTenantPermissions` for compatibility with other libraries, the `is_authenticated` is handy to be proxied to the authentication model(`UserProfile`)

# Incentive - background
Many multi-tenant applications require separate authentication/authorization models as this libraries support, but also object level permissions. `django-guardian` seems to be the library of choice for object-level permissions in django. 
In my effort to make these two libraries compatible, I stumbled upon this issue. Guardian has AnonymousUser support, by checking the `is_authenticated` property ([code](https://github.com/django-guardian/django-guardian/blob/devel/guardian/backends.py#L31-L35))

It makes sense, to proxy the property similar to the `is_active` and `is_anonymous` properties in the `AbstractBaseUserFacade`.


# I'm helping!

<!--
Thank you for submitting a Pull Request. We appreciate it!

Please, fill in all the required information
to make our review and merging processes easier.
-->

## Checklist

<!--
Please check everything that applies:
-->

- [x] I have double checked that there are no unrelated changes in this pull request (old patches, accidental config files, etc.)
- [x] I have created at least one test case for the changes I have made
- [ ] I have updated the documentation for the changes I have made
- [ ] I have added my changes to the `CHANGELOG.md`

## Pull Request type

<!--
Please try to limit your pull request to one type, submit multiple pull requests if needed.
-->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [x] Other (please describe):

## Related issue(s)

<!--
Mark what issues this Pull Request closes or references.

Format is:
- Closes #issue-number
- Refs #issue-number

Example. Refs #0
Documentation: https://blog.github.com/2013-05-14-closing-issues-via-pull-requests/
-->

## Other Information

<!--
If you have any other comments, feel free to share!
-->
