### PR TITLE
feat: add `domain_extra_data` parameter to tenant provisioning functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ We follow [Semantic Versions](https://semver.org/) starting at the `0.4.0` relea
 
 ## Unreleased
 
+### Features
+
+* Add `domain_extra_data` support to tenant provisioning utilities (`provision_tenant`, `create_public_tenant`) to pass extra fields to domain creation
+
+### Deprecations
+
+* Deprecate passing arbitrary `**kwargs` as owner fields to `create_public_tenant`; use `owner_extra_data={...}` instead, with a warning emitted when using the deprecated method (which still works as before for now)
+
 ## 2.2.1 (2025-10-07)
 
 ## What's Changed

--- a/django_test_app/companies/migrations/0005_domain_notes.py
+++ b/django_test_app/companies/migrations/0005_domain_notes.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("companies", "0004_company_type"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="domain",
+            name="notes",
+            field=models.CharField(blank=True, default="", max_length=255),
+        ),
+    ]

--- a/django_test_app/companies/models.py
+++ b/django_test_app/companies/models.py
@@ -38,4 +38,21 @@ class Company(TenantBase):
 
 
 class Domain(DomainMixin):
-    """This class is required for django_tenants."""
+    """Domain model used by django-tenants, extended for test coverage.
+
+    This test app defines a minimal domain model required by django-tenants
+    (`DomainMixin`), and adds an extra field (`notes`) specifically to exercise
+    the library's tenant provisioning hooks.
+
+    Notes about the `notes` field:
+    - It is *optional* (`blank=True`, default "") so it does not affect normal
+        domain creation.
+    - It provides a concrete, harmless extra attribute that tests can pass via
+        `domain_extra_data` to verify that provisioning functions forward domain
+        fields correctly (see `test_provision_tenant_domain_extra_data_is_used`).
+
+    This helps cover the edge case where a project extends its Domain model with
+    additional fields and expects them to be set at domain creation time.
+    """
+
+    notes = models.CharField(max_length=255, blank=True, default="")

--- a/docs/pages/installation.rst
+++ b/docs/pages/installation.rst
@@ -320,8 +320,9 @@ this for you.
 
 .. note::
 
-   ``create_public_tenant`` still accepts extra keyword arguments for owner fields,
-   but this is deprecated. Prefer passing owner fields via ``owner_extra_data``.
+   ``create_public_tenant`` still accepts extra keyword arguments for
+   owner fields, but this is deprecated. Prefer passing owner fields via
+   ``owner_extra_data``.
 
 Or, alternatively, use the management command:
 

--- a/docs/pages/installation.rst
+++ b/docs/pages/installation.rst
@@ -301,7 +301,19 @@ this for you.
 
    from tenant_users.tenants.utils import create_public_tenant
 
-   create_public_tenant(domain_url="public.domain.com", owner_email="admin@domain.com")
+   create_public_tenant(
+       domain_url="public.domain.com",
+       owner_email="admin@domain.com",
+       # optionally, pass extra fields for the Domain model
+       domain_extra_data={"notes": "created by installer"},
+       # optionally, pass extra fields for the owner user
+       owner_extra_data={"first_name": "Admin"},
+   )
+
+.. note::
+
+   ``create_public_tenant`` still accepts extra keyword arguments for owner fields,
+   but this is deprecated. Prefer passing owner fields via ``owner_extra_data``.
 
 Or, alternatively, use the management command:
 

--- a/docs/pages/installation.rst
+++ b/docs/pages/installation.rst
@@ -94,26 +94,34 @@ Using Multi-Type Tenants
 ========================
 
 If you're leveraging the `Multi-type Tenants feature
-<https://django-tenants.readthedocs.io/en/latest/use.html#multi-types-tenants>`_
-.. code-block:: python .. code-block:: python
+<https://django-tenants.readthedocs.io/en/latest/use.html#multi-types-tenants>`_,
+configure ``TENANT_TYPES`` in your ``settings.py``:
+
+.. code:: python
 
    TENANT_TYPES = {
       "public": {
          "APPS": [
-            "django.contrib.auth", "django.contrib.contenttypes",
-            "tenant_users.permissions", "tenant_users.tenants",
-            "companies", "users", # Add other apps as needed ],
-
+            "django.contrib.auth",
+            "django.contrib.contenttypes",
+            "tenant_users.permissions",
+            "tenant_users.tenants",
+            "companies",
+            "users",
+            # Add other apps as needed
+         ],
          "URLCONF": "myproject.urls.public",
-
       },
-
       "type1": {
          "APPS": [
-            "django.contrib.auth", "django.contrib.contenttypes",
-            "tenant_users.permissions", # Add other apps as needed ], },
-
-      # Add other tenant types as needed }
+            "django.contrib.auth",
+            "django.contrib.contenttypes",
+            "tenant_users.permissions",
+            # Add other apps as needed
+         ],
+      },
+      # Add other tenant types as needed
+   }
 
 .. important::
 
@@ -273,7 +281,7 @@ Unauthenticated users are allowed to proceed.
    ]
 
 2. Optionally, customize the error message by setting
-   ``TENANT_USERS_ACCESS_ERROR_MESSAGE`` in your ``settings.py```:
+   ``TENANT_USERS_ACCESS_ERROR_MESSAGE`` in your ``settings.py``:
 
 .. code:: python
 

--- a/docs/pages/using.rst
+++ b/docs/pages/using.rst
@@ -10,7 +10,7 @@ you need to know to get started.
 ***************************
 
 To set up a new tenant in your application, utilize
-:func:`tasks.create_public_tenant()
+:func:`tasks.provision_tenant()
 <tenant_users.tenants.tasks.provision_tenant>`:
 
 .. code:: python
@@ -21,7 +21,13 @@ To set up a new tenant in your application, utilize
    provision_tenant_owner = CustomUserModel.objects.get(email="admin@evilcorp.com")
 
 
-   tenant, domain = provision_tenant("EvilCorp", "evilcorp", provision_tenant_owner)
+   tenant, domain = provision_tenant(
+      "EvilCorp",
+      "evilcorp",
+      provision_tenant_owner,
+      # optionally, pass extra fields for the tenant's Domain model
+      domain_extra_data={"notes": "created by provisioning"},
+   )
 
 Using Multi-Type Tenants
 ========================
@@ -29,7 +35,7 @@ Using Multi-Type Tenants
 If you're leveraging the `Multi-type Tenants feature
 <https://django-tenants.readthedocs.io/en/latest/use.html#multi-types-tenants>`_
 from ``django-tenants``, use the ``tenant_type`` keyword when calling
-the :func:`utils.create_public_tenant()
+the :func:`tasks.provision_tenant()
 <tenant_users.tenants.tasks.provision_tenant>` function:
 
 .. code:: python
@@ -40,7 +46,12 @@ the :func:`utils.create_public_tenant()
    provision_tenant_owner = TenantUser.objects.get(email="admin@evilcorp.com")
 
    tenant, domain = provision_tenant(
-       "EvilCorp", "evilcorp", provision_tenant_owner, tenant_type="tenant_type"
+         "EvilCorp",
+         "evilcorp",
+         provision_tenant_owner,
+         tenant_type="tenant_type",
+         # optionally, pass extra fields for the tenant's Domain model
+         domain_extra_data={"notes": "multitype tenant"},
    )
 
 .. note::

--- a/tenant_users/tenants/tasks.py
+++ b/tenant_users/tenants/tasks.py
@@ -35,8 +35,9 @@ def provision_tenant(  # noqa: PLR0913
     tenant_type: str | None = None,
     schema_name: str | None = None,
     tenant_extra_data: dict[str, Any] | None = None,
+    domain_extra_data: dict[str, Any] | None = None,
 ):
-    """Creates and initializes a new tenant with specified attributes and default roles.
+    """Creates a new tenant and its domain with specified attributes and default roles.
 
     Args:
         tenant_name (str): The name of the tenant.
@@ -47,6 +48,7 @@ def provision_tenant(  # noqa: PLR0913
         tenant_type (str, optional): Type of the tenant, used with `HAS_MULTI_TYPE_TENANTS = True`.
         schema_name (str, optional): The schema name for the tenant. Defaults to a combination of the slug and a timestamp.
         tenant_extra_data (dict, optional): Additional data for the tenant model.
+        domain_extra_data (dict, optional): Additional data for the domain model.
 
     Returns:
         tuple: A tuple containing:
@@ -60,6 +62,9 @@ def provision_tenant(  # noqa: PLR0913
     """
     if tenant_extra_data is None:
         tenant_extra_data = {}
+
+    if domain_extra_data is None:
+        domain_extra_data = {}
 
     if not owner.is_active:
         raise InactiveError(INACTIVE_USER_ERROR_MESSAGE)
@@ -103,7 +108,7 @@ def provision_tenant(  # noqa: PLR0913
 
         # Create a domain associated with the tenant and mark as primary
         domain = DomainModel.objects.create(
-            domain=tenant_domain, tenant=tenant, is_primary=True
+            domain=tenant_domain, tenant=tenant, is_primary=True, **domain_extra_data
         )
 
         # Add the user to the tenant with provided roles

--- a/tests/test_tenants/test_utils.py
+++ b/tests/test_tenants/test_utils.py
@@ -7,6 +7,7 @@ from django_tenants.utils import get_public_schema_name, schema_context
 
 from django_test_app.companies.models import Company, Domain
 from django_test_app.users.models import TenantUser
+from tenant_users.permissions.models import UserTenantPermissions
 from tenant_users.tenants import utils
 from tenant_users.tenants.models import ExistsError, SchemaError
 
@@ -42,7 +43,13 @@ def test_create_public_tenant():
     domain = "domain.test"
 
     # Create public tenant with basic params
-    utils.create_public_tenant(domain, email)
+    public_tenant, created_domain, user = utils.create_public_tenant(domain, email)
+
+    assert public_tenant.schema_name == get_public_schema_name()
+    assert created_domain.tenant == public_tenant
+    assert created_domain.domain == domain
+    assert created_domain.is_primary
+    assert public_tenant.owner == user
 
     # Ensure expected objects all exist
     assert Domain.objects.filter(domain=domain).exists()
@@ -59,13 +66,167 @@ def test_create_public_tenant_with_specified_password():
     """Ensure password is set correct when specified during public tenant creation."""
     email = "user@domain.com"
     secret = "super_secure_123"  # noqa: S105
-    utils.create_public_tenant("domain.test", email, password=secret)
+    utils.create_public_tenant(
+        "domain.test", email, owner_extra_data={"password": secret}
+    )
 
     user = TenantUser.objects.get(email=email)
     assert user.tenants.filter(schema_name="public").exists()
 
     # Ensure the user is able to use the specified password
     assert user.check_password(secret)
+
+
+@pytest.mark.django_db
+@pytest.mark.no_db_setup
+def test_create_public_tenant_domain_extra_data_is_used():
+    """Ensures domain_extra_data is passed through to domain creation."""
+    domain = "domain.test"
+
+    _, created_domain, _ = utils.create_public_tenant(
+        domain,
+        "user@domain.com",
+        domain_extra_data={"notes": "hello"},
+    )
+
+    created_domain.refresh_from_db()
+    assert created_domain.domain == domain
+    assert created_domain.notes == "hello"
+
+
+@pytest.mark.django_db
+@pytest.mark.no_db_setup
+def test_create_public_tenant_owner_extra_data_is_used():
+    """Ensures owner_extra_data is passed through to owner creation."""
+    email = "user@domain.com"
+    domain = "domain.test"
+    owner_name = "Owner Name"
+
+    _, _, user = utils.create_public_tenant(
+        domain,
+        email,
+        owner_extra_data={"name": owner_name},
+    )
+
+    user.refresh_from_db()
+    assert user.email == email
+    assert user.name == owner_name
+    assert user.is_active is True
+
+
+@pytest.mark.django_db
+@pytest.mark.no_db_setup
+def test_create_public_tenant_deprecated_owner_extra_kwargs_warns_and_works():
+    """Ensures legacy **owner_extra kwargs emit a warning and are applied."""
+    email = "user-deprecated@domain.com"
+    domain = "domain.test"
+
+    with pytest.warns(DeprecationWarning, match=r"owner_extra_data"):
+        _, _, user = utils.create_public_tenant(domain, email, name="Deprecated Name")
+
+    user.refresh_from_db()
+    assert user.email == email
+    assert user.name == "Deprecated Name"
+
+
+@pytest.mark.django_db
+@pytest.mark.no_db_setup
+def test_create_public_tenant_deprecated_kwargs_do_not_override_new_owner_extra_data():
+    """Ensures explicit owner_extra_data wins over deprecated kwargs on conflicts."""
+    email = "user-deprecated2@domain.com"
+    domain = "domain.test"
+
+    with pytest.warns(
+        DeprecationWarning,
+        match="extra keyword arguments to create_public_tenant\\(\\) is deprecated",
+    ):
+        _, _, user = utils.create_public_tenant(
+            domain,
+            email,
+            owner_extra_data={"name": "Explicit new"},
+            name="Deprecated",
+        )
+
+    user.refresh_from_db()
+    assert user.name == "Explicit new"
+
+
+@pytest.mark.django_db
+@pytest.mark.no_db_setup
+def test_create_public_tenant_owner_flags_create_correct_permissions():
+    """Ensures is_staff/is_superuser are persisted via add_user()."""
+    email = "user@domain.com"
+    domain = "domain.test"
+
+    public_tenant, _, profile = utils.create_public_tenant(
+        domain,
+        email,
+        is_staff=True,
+        is_superuser=True,
+    )
+
+    with schema_context(public_tenant.schema_name):
+        perms = UserTenantPermissions.objects.get(profile=profile)
+        assert perms.is_staff is True
+        assert perms.is_superuser is True
+
+
+@pytest.mark.django_db
+@pytest.mark.no_db_setup
+def test_create_public_tenant_is_atomic_on_domain_creation_error():
+    """Ensures the transaction rolls back if domain creation fails."""
+    email = "user@domain.com"
+    domain = "domain.test"
+
+    with pytest.raises(TypeError):
+        utils.create_public_tenant(
+            domain,
+            email,
+            domain_extra_data={"does_not_exist": "boom"},
+        )
+
+    # If atomic is working, nothing should have been persisted.
+    assert not TenantUser.objects.filter(email=email).exists()
+    assert not Company.objects.filter(schema_name=get_public_schema_name()).exists()
+    assert not Domain.objects.filter(domain=domain).exists()
+
+
+@pytest.mark.django_db
+@pytest.mark.no_db_setup
+def test_create_public_tenant_is_atomic_on_schema_error(settings):
+    """Ensures the transaction rolls back if schema validation fails."""
+    # Create invalid multitype configuration
+    settings.HAS_MULTI_TYPE_TENANTS = True
+    settings.TENANT_TYPES = {}
+
+    email = "user@domain.com"
+    domain = "domain.test"
+
+    public_name = get_public_schema_name()
+    with pytest.raises(
+        SchemaError,
+        match=f"Please define a '{public_name}' tenant type.",
+    ):
+        utils.create_public_tenant(domain, email)
+
+    assert not TenantUser.objects.filter(email=email).exists()
+    assert not Company.objects.filter(schema_name=get_public_schema_name()).exists()
+    assert not Domain.objects.filter(domain=domain).exists()
+
+
+@pytest.mark.django_db
+@pytest.mark.no_db_setup
+def test_create_public_tenant_second_call_creates_nothing():
+    """Ensures ExistsError is raised before creating a second owner/domain."""
+    utils.create_public_tenant("domain1.test", "user1@domain.com")
+    domain2 = "domain2.test"
+    email2 = "user2@domain.com"
+
+    with pytest.raises(ExistsError, match="Public tenant already exists"):
+        utils.create_public_tenant(domain2, email2)
+
+    assert not TenantUser.objects.filter(email=email2).exists()
+    assert not Domain.objects.filter(domain=domain2).exists()
 
 
 @patch("tenant_users.tenants.utils.get_tenant_model")


### PR DESCRIPTION
# I'm helping!

## Checklist

- [x] I have double checked that there are no unrelated changes in this pull request (old patches, accidental config files, etc.)
- [x] I have created at least one test case for the changes I have made
- [x] I have updated the documentation for the changes I have made
- [x] I have added my changes to the `CHANGELOG.md`

## Pull Request type

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Documentation content changes
- [x] Other: more tests

## Related issue

Closes #897 

In a nutshell, domain creation is part of the tenant provisioning workflow, and domain model customization is a common extension point in multi-tenant apps. A small, explicit `domain_extra_data` hook avoids copy/paste provisioning logic and keeps domain creation atomic with tenant creation.

## Changes that I made

### 1) `provision_tenant` accepts `domain_extra_data`

```python
# proposed new API
provision_tenant(
    ...,  # existing arguments
    tenant_extra_data: dict[str, Any] | None = None,
    domain_extra_data: dict[str, Any] | None = None,
) -> tuple[tenant, domain, owner]
```

Adds a new optional argument `domain_extra_data: dict[str, Any] | None = None` and passes it through to the domain creation call:

```py
DomainModel.objects.create(
    domain=tenant_domain,
    tenant=tenant,
    is_primary=True,
    **domain_extra_data,
)
```

This keeps tenant creation + domain creation as a single cohesive provisioning action, while allowing customization.

### 2) `create_public_tenant` also supports domain customization and clarifies owner extras

```python
# proposed new API
create_public_tenant(
    ...,  # existing arguments
    tenant_extra_data: dict[str, Any] | None = None,
    domain_extra_data: dict[str, Any] | None = None,
    owner_extra_data: dict[str, Any] | None = None,
    # keep **owner_extra temporarily, but deprecated
) -> tuple[tenant, domain, owner]
```

`create_public_tenant` now accepts:

- `domain_extra_data: dict[str, Any] | None = None`
- `owner_extra_data: dict[str, Any] | None = None`

and uses them explicitly when creating the domain and owner user.

Additionally, `**owner_extra` is treated as *deprecated* (with a `DeprecationWarning`) to avoid mixing unrelated concerns in `**kwargs` and to make the API clearer.

## Tests / environment

### Test environment

- <u>PostgreSQL 17</u> 
- <u>uv 0.9.9</u>
- <u>Python 3.13</u>
- <u>Pytest 9.0.2</u>
- <u>Django 5.2.10</u>

### Test status

➜ 67 passed
➜ 2 failed... but appear unrelated to my changes! The failures are:

- `tests/test_tenants/test_permission_models.py::test_tenant_perms_default_queryset` (expects 4 queries, but only 2 are executed)
- `tests/test_tenants/test_permission_models.py::test_tenant_perms_custom_queryset` (expects 4 queries, but only 2 are executed)

These look like outdated query-count assertions rather than a functional regression in tenant/domain provisioning.